### PR TITLE
Changed default value for info to empty string so we don't need to ...

### DIFF
--- a/adjacent/utils.py
+++ b/adjacent/utils.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from cent.core import generate_token
 
 
-def get_connection_parameters(user, info=None):
+def get_connection_parameters(user, info=''):
     timestamp = str(int(time.time()))
     user_pk = str(user.pk) if user.is_authenticated() else ""
     token = generate_token(


### PR DESCRIPTION
Had filed an issue earlier this evening in the examples module. Then discovered the problem was the default None value for info in the adjacent module.
